### PR TITLE
Fix runtime error when log group names are defined through CF intrinsic functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoi/serverless-log-dumpster",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Serverless Framework plugin to archive AWS CloudWatch log groups before deletion",
   "main": "dist/index.js",
   "repository": "git@github.com:xoeye/serverless-log-dumpster.git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,11 @@ export default class LogDumpsterPlugin {
     return logicalToPhysical
   }
 
-  populatePhysicalIds(logGroups: LogGroup[], logicalToPhysical: Record<string, string>): void {
+  populatePhysicalIds(
+    _logGroups: LogGroup[],
+    logicalToPhysical: Record<string, string>
+  ): LogGroup[] {
+    const logGroups: LogGroup[] = JSON.parse(JSON.stringify(_logGroups))
     for (const logGroup of logGroups) {
       if (typeof logGroup.name != 'string') {
         this.log(`Log group name is defined by instrinsic function:`, logGroup)
@@ -131,6 +135,7 @@ export default class LogDumpsterPlugin {
         }
       }
     }
+    return logGroups
   }
 
   async findRemovedLogGroups(): Promise<LogGroup[]> {
@@ -144,9 +149,7 @@ export default class LogDumpsterPlugin {
     const logicalToPhysical = await this.fetchCurrentStackResources()
 
     const logGroups = diffFindRemovedLogGroups(deployedTemplate, newTemplate)
-    this.populatePhysicalIds(logGroups, logicalToPhysical)
-
-    return logGroups
+    return this.populatePhysicalIds(logGroups, logicalToPhysical)
   }
 
   async dumpRemovedLogGroups(removedLogGroups: LogGroup[]): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,21 @@
 import { inspect } from 'util'
 import { diffFindRemovedLogGroups } from './cfnTemplateDiff'
 import { dumpLogGroup } from './logDumper'
-import { AwsApiCall, JSONRepresentable } from './types/awsApi'
+import { AwsApiCall, JSONRepresentable, ListStackResourcesResult } from './types/awsApi'
 import { LogGroup } from './types/logGroup'
 import { AWSProvider, AWSServiceProvider, Serverless } from './types/serverless'
 
 const LOG_PREFIX = '[LogDumpster]'
+
+export class PhysicalIDNotFoundError extends Error {
+  constructor(logGroup: LogGroup) {
+    const logGroupStr = inspect(logGroup, {
+      colors: true,
+      depth: null,
+    })
+    super(`Failed to get physical ID for log group: ${logGroupStr}`)
+  }
+}
 
 export default class LogDumpsterPlugin {
   serverless: Serverless
@@ -66,7 +76,7 @@ export default class LogDumpsterPlugin {
   }
 
   log(str: string, ...objects: unknown[]): void {
-    let objects_str = objects.map((e) => inspect(e, { colors: true })).join('\n')
+    let objects_str = objects.map((e) => inspect(e, { colors: true, depth: null })).join('\n')
     if (objects_str.length > 0) objects_str = '\n' + objects_str
 
     this.serverless.cli.log(`${LOG_PREFIX} ${str}${objects_str}`)
@@ -75,9 +85,9 @@ export default class LogDumpsterPlugin {
   async onBeforeUpdateStack(): Promise<void> {
     const removedLogGroups = await this.findRemovedLogGroups()
     if (removedLogGroups.length > 0) {
-      const removed_str = removedLogGroups.map((group) => group.name).join(', ')
+      const removed_names = removedLogGroups.map((group) => group.name)
 
-      this.log(`Found the following log groups to be replaced or removed: ${removed_str}`)
+      this.log('Found the following log groups to be replaced or removed:', ...removed_names)
 
       if (this.serviceProvider.shouldNotDeploy) {
         this.log('Dry-run was requested, skipping log export.')
@@ -90,6 +100,39 @@ export default class LogDumpsterPlugin {
     }
   }
 
+  async fetchCurrentStackResources(): Promise<Record<string, string>> {
+    const params = { StackName: this.serviceProvider.stackName }
+    const physicalIds = (await this.provider.request(
+      'CloudFormation',
+      'listStackResources',
+      params
+    )) as unknown as ListStackResourcesResult
+
+    const logicalToPhysical: Record<string, string> = {}
+    for (const resource of physicalIds.StackResourceSummaries) {
+      logicalToPhysical[resource.LogicalResourceId] = resource.PhysicalResourceId
+    }
+    this.log('Obtained current resources from deployed stack.')
+
+    return logicalToPhysical
+  }
+
+  populatePhysicalIds(logGroups: LogGroup[], logicalToPhysical: Record<string, string>): void {
+    for (const logGroup of logGroups) {
+      if (typeof logGroup.name != 'string') {
+        this.log(`Log group name is defined by instrinsic function:`, logGroup)
+
+        const physicalId = logicalToPhysical[logGroup.logicalId]
+        if (physicalId) {
+          this.log(`Using physical ID from ListResources: ${physicalId}`)
+          logGroup.name = physicalId
+        } else {
+          throw new PhysicalIDNotFoundError(logGroup)
+        }
+      }
+    }
+  }
+
   async findRemovedLogGroups(): Promise<LogGroup[]> {
     const params = { StackName: this.serviceProvider.stackName, TemplateStage: 'Original' }
     const resp = await this.provider.request('CloudFormation', 'getTemplate', params)
@@ -98,7 +141,12 @@ export default class LogDumpsterPlugin {
       JSON.stringify(this.serviceProvider.compiledCloudFormationTemplate)
     )
 
-    return diffFindRemovedLogGroups(deployedTemplate, newTemplate)
+    const logicalToPhysical = await this.fetchCurrentStackResources()
+
+    const logGroups = diffFindRemovedLogGroups(deployedTemplate, newTemplate)
+    this.populatePhysicalIds(logGroups, logicalToPhysical)
+
+    return logGroups
   }
 
   async dumpRemovedLogGroups(removedLogGroups: LogGroup[]): Promise<void> {
@@ -122,7 +170,7 @@ export default class LogDumpsterPlugin {
     )
 
     for (const logGroup of removedLogGroups) {
-      this.log(`Starting export of ${logGroup.name}`, logGroup)
+      this.log(`Starting export of ${logGroup.name}`)
       const exportTime = await dump(logGroup)
       this.log(`Completed export in ${exportTime} seconds`)
     }

--- a/src/logDumper.ts
+++ b/src/logDumper.ts
@@ -39,7 +39,8 @@ export const dumpLogGroup = async (
   const taskName = `${logGroup.logicalId}-${now}"`
 
   // Leading slash unwanted if exporting to root of bucket
-  const nameWithoutPrefix = logGroup.name.replace(/^\//, '')
+  const name = logGroup.name as string
+  const nameWithoutPrefix = name.replace(/^\//, '')
 
   // Remove leading or trailing slashes from configured prefix. Allows '/' or '' as root of bucket
   let sanitizedPrefix = pathPrefix.replace(/^\//, '').replace(/\/$/, '')
@@ -52,7 +53,7 @@ export const dumpLogGroup = async (
 
   const createParams: CreateExportTaskParams = {
     taskName,
-    logGroupName: logGroup.name,
+    logGroupName: name,
     destination: bucketName,
     destinationPrefix: exportPath,
     from: 0,

--- a/src/test/mocks/awsProvider.mock.ts
+++ b/src/test/mocks/awsProvider.mock.ts
@@ -11,6 +11,8 @@ import {
   GetTemplateParams,
   GetTemplateResult,
   JSONRepresentable,
+  ListStackResourcesParams,
+  ListStackResourcesResult,
 } from '../../types/awsApi'
 
 export const sampleTemplate = {
@@ -19,6 +21,22 @@ export const sampleTemplate = {
       Type: 'AWS::Logs::LogGroup',
       Properties: {
         LogGroupName: '/aws/lambda/log-group-a',
+      },
+    },
+    LogGroupB: {
+      Type: 'AWS::Logs::LogGroup',
+      Properties: {
+        LogGroupName: {
+          'Fn::Join': [
+            '/',
+            [
+              '/aws/appsync/apis',
+              {
+                'Fn::GetAtt': ['TestAPILogicalResource', 'ApiId'],
+              },
+            ],
+          ],
+        },
       },
     },
   },
@@ -34,6 +52,18 @@ export class MockCloudFormation {
   getTemplate(_params: GetTemplateParams): Promise<GetTemplateResult> {
     return ResolvedPromise<GetTemplateResult>({
       TemplateBody: JSON.stringify(sampleTemplate),
+    })
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  listStackResources(_params: ListStackResourcesParams): Promise<ListStackResourcesResult> {
+    return ResolvedPromise<ListStackResourcesResult>({
+      StackResourceSummaries: [
+        {
+          LogicalResourceId: 'LogGroupB',
+          PhysicalResourceId: '/aws/appsync/apis/log-group-b',
+          ResourceType: 'AWS::Logs::LogGroup',
+        },
+      ],
     })
   }
 }

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -40,9 +40,10 @@ describe('serverless plugin log dumping', () => {
 
     const logGroupPath = '/aws/appsync/apis/log-group-b-nonexistant'
     const logicalToPhysical = { 'log-group-b-nonexistant': logGroupPath }
-    plugin.populatePhysicalIds(logGroups, logicalToPhysical)
+    const newLogGroups = plugin.populatePhysicalIds(logGroups, logicalToPhysical)
 
-    assert.equal(logGroups[0].name, logGroupPath)
+    assert.notEqual(logGroups[0].name, newLogGroups[0].name)
+    assert.equal(newLogGroups[0].name, logGroupPath)
   })
 
   it('throw an error if physical ID cannot be found', async () => {

--- a/src/types/awsApi.ts
+++ b/src/types/awsApi.ts
@@ -1,6 +1,14 @@
+export type JSONObject =
+  | string
+  | number
+  | boolean
+  | { [name: string]: JSONObject }
+  | Array<JSONObject>
+
 export interface JSONRepresentable {
-  [name: string | symbol]: string | number | JSONRepresentable
+  [name: string | symbol | number]: string | number | boolean | JSONObject
 }
+
 export type AwsApiCall<TParams, TRes> = (params: TParams) => Promise<TRes>
 
 /**
@@ -93,4 +101,21 @@ export type GetTemplate = AwsApiCall<GetTemplateParams, GetTemplateResult>
  */
 export interface CloudFormationApi {
   getTemplate: GetTemplate
+}
+
+/**
+ * Cloudformation::ListResources
+ */
+export interface ListStackResourcesParams {
+  StackName: string
+}
+
+export interface StackResource {
+  LogicalResourceId: string
+  PhysicalResourceId: string
+  ResourceType: string
+}
+
+export interface ListStackResourcesResult {
+  StackResourceSummaries: Array<StackResource>
 }

--- a/src/types/logGroup.ts
+++ b/src/types/logGroup.ts
@@ -1,4 +1,6 @@
+import { JSONRepresentable } from './awsApi'
+
 export interface LogGroup {
   logicalId: string
-  name: string
+  name: string | JSONRepresentable
 }


### PR DESCRIPTION
If a log group's name in a cloudformation is defined using an intrinsic function, the following error would occur:
```
Serverless: Validating template...
Serverless: [LogDumpster] Found the following log groups to be replaced or removed: [object Object]
Serverless: [LogDumpster] Starting export of [object Object]
 
 Type Error ----------------------------------------------
 
  TypeError: logGroup.name.replace is not a function
```

This PR extends the somewhat imperative shell that is `findRemovedLogGroups` to also get the physical IDs of currently deployed resources and creates a mapping of logical to physical IDs. This mapping is only used a as a fallback in case the log group's name is not defined as a hardcoded string.